### PR TITLE
Add SIP022 AEAD-2022 TCP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (HAVE_SPLICE)
     add_definitions(-DHAVE_SPLICE=1)
 endif()
 
-set(MPROXY_SOURCES parse_forward_param.c dns_forward.c connector.c http_connector.c evhtp_proxy.c evhtp_sock_relay.c lru.c utils.c log.c)
+set(MPROXY_SOURCES blake3.c parse_forward_param.c dns_forward.c connector.c http_connector.c evhtp_proxy.c evhtp_sock_relay.c lru.c utils.c log.c)
 if (MSVC)
     add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
     set(MPROXY_SOURCES ${MPROXY_SOURCES} bsd_getopt.c )

--- a/blake3.c
+++ b/blake3.c
@@ -1,0 +1,148 @@
+#include "blake3.h"
+#include <string.h>
+
+static const uint32_t IV[8] = {
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+    0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
+};
+
+static const uint8_t SIGMA[7][16] = {
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+    {2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8},
+    {3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1},
+    {10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6},
+    {12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4},
+    {9, 14, 11, 5, 8, 12, 15, 1, 13, 10, 0, 7, 2, 4, 6, 3},
+    {11, 15, 5, 0, 1, 9, 8, 2, 14, 12, 3, 4, 7, 10, 6, 13}
+};
+
+static uint32_t load32(const void *src) {
+    uint32_t w;
+    memcpy(&w, src, sizeof(w));
+    return w;
+}
+
+static void store32(void *dst, uint32_t w) {
+    memcpy(dst, &w, sizeof(w));
+}
+
+inline static uint32_t rotate_right(uint32_t x, int n) {
+    return (x >> n) | (x << (32 - n));
+}
+
+inline static void g(uint32_t state[16], int a, int b, int c, int d, uint32_t mx, uint32_t my) {
+    state[a] = state[a] + state[b] + mx;
+    state[d] = rotate_right(state[d] ^ state[a], 16);
+    state[c] = state[c] + state[d];
+    state[b] = rotate_right(state[b] ^ state[c], 12);
+    state[a] = state[a] + state[b] + my;
+    state[d] = rotate_right(state[d] ^ state[a], 8);
+    state[c] = state[c] + state[d];
+    state[b] = rotate_right(state[b] ^ state[c], 7);
+}
+
+inline static void round_fn(uint32_t state[16], const uint32_t m[16], int r) {
+    const uint8_t *s = SIGMA[r];
+    g(state, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+    g(state, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+    g(state, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+    g(state, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+    g(state, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+    g(state, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+    g(state, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+    g(state, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+}
+
+static void compress(const uint32_t cv[8], const uint32_t m[16], uint64_t t, uint32_t b, uint32_t f, uint32_t out[8]) {
+    uint32_t state[16];
+    memcpy(&state[0], cv, 32);
+    memcpy(&state[8], IV, 16);
+    state[12] = (uint32_t)t;
+    state[13] = (uint32_t)(t >> 32);
+    state[14] = b;
+    state[15] = f;
+
+    for (int r = 0; r < 7; r++) {
+        round_fn(state, m, r);
+    }
+
+    for (int i = 0; i < 8; i++) {
+        out[i] = state[i] ^ state[i + 8];
+        out[i] ^= cv[i];
+    }
+}
+
+typedef struct {
+    uint32_t cv[8];
+    uint64_t chunk_counter;
+    uint8_t buf[64];
+    uint8_t buf_len;
+    uint32_t flags;
+} blake3_hasher;
+
+enum {
+    CHUNK_START = 1 << 0,
+    CHUNK_END = 1 << 1,
+    PARENT = 1 << 2,
+    ROOT = 1 << 3,
+    KEYED_HASH = 1 << 4,
+};
+
+static void blake3_hasher_init_common(blake3_hasher *self, const uint8_t *key, uint32_t flags) {
+    if (key) {
+        for (int i = 0; i < 8; i++) self->cv[i] = load32(key + i * 4);
+    } else {
+        memcpy(self->cv, IV, 32);
+    }
+    self->chunk_counter = 0;
+    self->buf_len = 0;
+    self->flags = flags;
+}
+
+static void blake3_hasher_update(blake3_hasher *self, const uint8_t *input, size_t input_len) {
+    while (input_len > 0) {
+        if (self->buf_len == 64) {
+            uint32_t m[16];
+            for (int i = 0; i < 16; i++) m[i] = load32(self->buf + i * 4);
+            uint32_t flags = self->flags;
+            if (self->chunk_counter == 0) flags |= CHUNK_START;
+            uint32_t out[8];
+            compress(self->cv, m, self->chunk_counter, 64, flags, out);
+            memcpy(self->cv, out, 32);
+            self->buf_len = 0;
+            self->chunk_counter++;
+        }
+        size_t take = 64 - self->buf_len;
+        if (take > input_len) take = input_len;
+        memcpy(self->buf + self->buf_len, input, take);
+        self->buf_len += (uint8_t)take;
+        input += take;
+        input_len -= take;
+    }
+}
+
+static void blake3_hasher_finalize(blake3_hasher *self, uint8_t *out, size_t out_len) {
+    uint32_t m[16] = {0};
+    for (int i = 0; i < 16; i++) m[i] = load32(self->buf + i * 4);
+    uint32_t flags = self->flags | CHUNK_END | ROOT;
+    if (self->chunk_counter == 0) flags |= CHUNK_START;
+    uint32_t result[8];
+    compress(self->cv, m, self->chunk_counter, self->buf_len, flags, result);
+    for (int i = 0; i < 8 && i * 4 < out_len; i++) {
+        store32(out + i * 4, result[i]);
+    }
+}
+
+void blake3_hash(const uint8_t *input, size_t input_len, uint8_t *out, size_t out_len) {
+    blake3_hasher hasher;
+    blake3_hasher_init_common(&hasher, NULL, 0);
+    blake3_hasher_update(&hasher, input, input_len);
+    blake3_hasher_finalize(&hasher, out, out_len);
+}
+
+void blake3_keyed_hash(const uint8_t *key, const uint8_t *input, size_t input_len, uint8_t *out, size_t out_len) {
+    blake3_hasher hasher;
+    blake3_hasher_init_common(&hasher, key, KEYED_HASH);
+    blake3_hasher_update(&hasher, input, input_len);
+    blake3_hasher_finalize(&hasher, out, out_len);
+}

--- a/blake3.h
+++ b/blake3.h
@@ -1,0 +1,15 @@
+#ifndef BLAKE3_H
+#define BLAKE3_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BLAKE3_KEY_LEN 32
+#define BLAKE3_OUT_LEN 32
+#define BLAKE3_BLOCK_LEN 64
+#define BLAKE3_CHUNK_LEN 1024
+
+void blake3_hash(const uint8_t *input, size_t input_len, uint8_t *out, size_t out_len);
+void blake3_keyed_hash(const uint8_t *key, const uint8_t *input, size_t input_len, uint8_t *out, size_t out_len);
+
+#endif

--- a/encrypt.c
+++ b/encrypt.c
@@ -26,8 +26,13 @@
 #endif
 
 #include "encrypt.h"
+#include "blake3.h"
 #include <assert.h>
 #include <stdint.h>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#endif
 
 #if defined(USE_CRYPTO_OPENSSL)
 
@@ -146,6 +151,10 @@ static struct {
     {"aes-256-ocb",       32,   12,  16, NULL, _(CIPHER_UNSUPPORTED,    CCAlgorithmInvalid) },
     // ss quivalent chacha20-ietf-poly1305
     {"chacha20-poly1305", 32,   12,  16, NULL, _("CHACHA20-POLY1305",   CCAlgorithmInvalid) },
+    {"2022-blake3-aes-128-gcm", 16, 12, 16, NULL, _("AES-128-GCM",      CCAlgorithmInvalid) },
+    {"2022-blake3-aes-192-gcm", 24, 12, 16, NULL, _("AES-192-GCM",      CCAlgorithmInvalid) },
+    {"2022-blake3-aes-256-gcm", 32, 12, 16, NULL, _("AES-256-GCM",      CCAlgorithmInvalid) },
+    {"2022-blake3-chacha20-poly1305", 32, 12, 16, NULL, _("CHACHA20-POLY1305", CCAlgorithmInvalid) },
 };
 
 #undef _
@@ -956,12 +965,17 @@ void enc_key_init(int method, const char *pass)
             FATAL("Cannot initialize cipher");
         } while (0);
     }
-    const digest_type_t *md = get_digest_type("MD5");
-    if (md == NULL) {
-        FATAL("MD5 Digest not found in crypto library");
-    }
+    if (method >= AES_128_GCM_2022) {
+        blake3_hash((const uint8_t *)pass, strlen(pass), enc_key, supported_ciphers[method].key_size);
+        enc_key_len = supported_ciphers[method].key_size;
+    } else {
+        const digest_type_t *md = get_digest_type("MD5");
+        if (md == NULL) {
+            FATAL("MD5 Digest not found in crypto library");
+        }
 
-    enc_key_len = bytes_to_key(cipher, md, (const uint8_t *)pass, enc_key, iv);
+        enc_key_len = bytes_to_key(cipher, md, (const uint8_t *)pass, enc_key, iv);
+    }
     if (enc_key_len == 0) {
         FATAL("Cannot generate key and IV");
     }
@@ -1049,9 +1063,13 @@ uint8_t *k)
 
     switch (enc_method) {
     case CHACHA20_IETF_POLY1305:
+    case CHACHA20_POLY1305_2022:
     case AES_128_GCM:
     case AES_192_GCM:
     case AES_256_GCM:
+    case AES_128_GCM_2022:
+    case AES_192_GCM_2022:
+    case AES_256_GCM_2022:
 #if USE_CRYPTO_OPENSSL
     case AES_128_OCB:
     case AES_192_OCB:
@@ -1108,9 +1126,13 @@ uint8_t *n, uint8_t *k)
 
     switch (enc_method) {
     case CHACHA20_IETF_POLY1305:
+    case CHACHA20_POLY1305_2022:
     case AES_128_GCM:
     case AES_192_GCM:
     case AES_256_GCM:
+    case AES_128_GCM_2022:
+    case AES_192_GCM_2022:
+    case AES_256_GCM_2022:
 
 #if USE_CRYPTO_OPENSSL
     case AES_128_OCB:
@@ -1208,11 +1230,18 @@ int crypto_hkdf(const unsigned char *salt,
 static void
 aead_cipher_ctx_set_key(cipher_ctx_t *cipher_ctx, int enc)
 {
-    int err = crypto_hkdf(
-        cipher_ctx->salt, supported_ciphers[enc_method].key_size,
-        enc_key, supported_ciphers[enc_method].key_size,
-        (uint8_t *)SUBKEY_INFO, strlen(SUBKEY_INFO),
-        cipher_ctx->skey, supported_ciphers[enc_method].key_size);
+    int err;
+    if (enc_method >= AES_128_GCM_2022) {
+        blake3_keyed_hash(enc_key, cipher_ctx->salt, supported_ciphers[enc_method].key_size,
+                         cipher_ctx->skey, supported_ciphers[enc_method].key_size);
+        err = 0;
+    } else {
+        err = crypto_hkdf(
+            cipher_ctx->salt, supported_ciphers[enc_method].key_size,
+            enc_key, supported_ciphers[enc_method].key_size,
+            (uint8_t *)SUBKEY_INFO, strlen(SUBKEY_INFO),
+            cipher_ctx->skey, supported_ciphers[enc_method].key_size);
+    }
     if (err) {
         FATAL("Unable to generate subkey");
     }
@@ -1287,36 +1316,46 @@ aead_encrypt(char *ciphertext, char *plaintext, ssize_t *len, struct enc_ctx *ct
     }
 
     int err = CRYPTO_ERROR;
-    size_t salt_ofst = 0;
     size_t salt_len = enc_get_key_len();
     size_t tag_len = enc_get_tag_len();
-
-    if (!ctx->init) {
-        salt_ofst = salt_len;
-    }
-
-    // TODO: loop
-    if (*len > CHUNK_SIZE_MASK) {
-        *len = CHUNK_SIZE_MASK;
-    }
-
-    size_t out_len = salt_ofst + 2 * tag_len + *len + CHUNK_SIZE_LEN;
+    size_t nlen = supported_ciphers[enc_method].iv_size;
 
     if (!ctx->init) {
         rand_bytes(ctx->evp.salt, salt_len);
         memcpy(ciphertext, ctx->evp.salt, salt_len);
         aead_cipher_ctx_set_key(&ctx->evp, 1);
         ctx->init = 1;
+
+        if (enc_method >= AES_128_GCM_2022) {
+            // SIP022 AEAD-2022: First chunk is header, no length prefix
+            size_t clen = *len + tag_len;
+            err = aead_cipher_encrypt(&ctx->evp, (uint8_t *)(ciphertext + salt_len), &clen,
+                                     (uint8_t *)plaintext, *len, NULL, 0, ctx->evp.nonce, ctx->evp.skey);
+            if (err) return CRYPTO_ERROR;
+            nonce_increment(ctx->evp.nonce, nlen);
+            return salt_len + clen;
+        }
+
+        // Standard AEAD: First chunk is Len + Data, but salt is prepended
+        err = aead_chunk_encrypt(&ctx->evp,
+            (uint8_t *)plaintext,
+            (uint8_t *)ciphertext + salt_len,
+            ctx->evp.nonce, *len);
+        if (err) return err;
+        return salt_len + 2 * tag_len + *len + CHUNK_SIZE_LEN;
+    } else {
+        // TODO: loop
+        if (*len > CHUNK_SIZE_MASK) {
+            *len = CHUNK_SIZE_MASK;
+        }
+
+        err = aead_chunk_encrypt(&ctx->evp,
+            (uint8_t *)plaintext,
+            (uint8_t *)ciphertext,
+            ctx->evp.nonce, *len);
+        if (err) return err;
+        return 2 * tag_len + *len + CHUNK_SIZE_LEN;
     }
-
-    err = aead_chunk_encrypt(&ctx->evp,
-        (uint8_t *)plaintext,
-        (uint8_t *)ciphertext + salt_ofst,
-        ctx->evp.nonce, *len);
-    if (err)
-        return err;
-
-    return out_len;
 }
 
 static int

--- a/encrypt.h
+++ b/encrypt.h
@@ -164,6 +164,10 @@ enum{
     AES_192_OCB,
     AES_256_OCB,
     CHACHA20_IETF_POLY1305,
+    AES_128_GCM_2022,
+    AES_192_GCM_2022,
+    AES_256_GCM_2022,
+    CHACHA20_POLY1305_2022,
     CIPHER_NUM,      /* must be last */
 };
 

--- a/ss_connector.c
+++ b/ss_connector.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <time.h>
 #ifdef _WIN32
 # include <malloc.h>
 #endif
@@ -34,6 +35,7 @@ typedef struct ss_conn_t {
 	uint16_t port;
 	connect_callback cb;
 	void *arg;
+	int response_header_skipped;
 } ss_conn;
 
 
@@ -103,7 +105,7 @@ static enum bufferevent_filter_result input_filter(struct evbuffer *src, struct 
         vec_dst[0].iov_len = 0;
 
         int consume = evbuffer_get_length(src);
-        int produce = aead_decrypt(vec_dst[0].iov_base, ciphertext, &consume, &conn->e_ctx);
+        int produce = aead_decrypt(vec_dst[0].iov_base, ciphertext, &consume, &conn->d_ctx);
         if (produce < 0) {
                 LOGE("aead decrypt failed"); 
                 return BEV_ERROR; 
@@ -112,6 +114,15 @@ static enum bufferevent_filter_result input_filter(struct evbuffer *src, struct 
             return BEV_NEED_MORE;
         }
         else {
+            if (produce > 0 && g_ss_method >= AES_128_GCM_2022 && !conn->response_header_skipped) {
+                size_t salt_len = enc_get_key_len();
+                size_t header_len = 1 + 8 + salt_len;
+                if (produce >= header_len) {
+                    memmove(vec_dst[0].iov_base, (char *)vec_dst[0].iov_base + header_len, produce - header_len);
+                    produce -= header_len;
+                    conn->response_header_skipped = 1;
+                }
+            }
             evbuffer_drain(src, consume);
             vec_dst[0].iov_len = produce;
 
@@ -178,7 +189,7 @@ static enum bufferevent_filter_result output_filter(struct evbuffer *src, struct
             vec_dst[0].iov_len = 0;
 
             //int consume = evbuffer_get_length(src);
-            int produce = aead_encrypt(vec_dst[0].iov_base, plaintext, &consume, &conn->d_ctx);
+            int produce = aead_encrypt(vec_dst[0].iov_base, plaintext, &consume, &conn->e_ctx);
             if (produce < 0) {
                 LOGE("aead encrypt failed");
                 return BEV_ERROR;
@@ -246,18 +257,38 @@ static void ss_eventcb(struct bufferevent *bev, short what, void *ctx)
 			|  1   | Variable |    2     |
 			+------+----------+----------+
 			*/
-			char data[1 + 1 + 255 + 2] = {0x03, };  // DOMAINNAME: X'03
+			char data[1024];
+			size_t data_len = 0;
+			if (g_ss_method >= AES_128_GCM_2022) {
+				// SIP022 AEAD-2022 Header
+				uint64_t ts = (uint64_t)time(NULL);
+				data[0] = 0; // type: HeaderTypeClientPacket
+				data[1] = (ts >> 56) & 0xFF;
+				data[2] = (ts >> 48) & 0xFF;
+				data[3] = (ts >> 40) & 0xFF;
+				data[4] = (ts >> 32) & 0xFF;
+				data[5] = (ts >> 24) & 0xFF;
+				data[6] = (ts >> 16) & 0xFF;
+				data[7] = (ts >> 8) & 0xFF;
+				data[8] = ts & 0xFF;
+				data[9] = 0; // padding length high
+				data[10] = 0; // padding length low
+				data_len = 11;
+			}
+
+			data[data_len++] = 0x03; // ATYP: DOMAINNAME
 			size_t domain_len = strlen(conn->host);
 			assert(domain_len <= 255);
+			data[data_len++] = (uint8_t)domain_len;
+			memcpy(data + data_len, conn->host, domain_len);
+			data_len += domain_len;
 			uint16_t net_port = htons(conn->port);
-
-			data[1] = domain_len;
-			memcpy(data + 2, conn->host, domain_len);
-			memcpy(data + 2 + domain_len, &net_port, 2);
+			memcpy(data + data_len, &net_port, 2);
+			data_len += 2;
 
             /* currently BEV_OPT_DEFER_CALLBACKS no effect with bufferevent_filter_new(), so defer it manually */
             evbuffer_defer_callbacks(bufferevent_get_output(bev_filter), bufferevent_get_base(bev_filter));
-            bufferevent_write(bev_filter, data, 1 + 1 + domain_len + 2);
+            bufferevent_write(bev_filter, data, data_len);
 
             conn->cb(bev_filter, conn->arg);
 		} else {


### PR DESCRIPTION
This PR adds support for the Shadowsocks AEAD-2022 protocol (SIP022) for TCP. 

Key changes:
1. **BLAKE3 Implementation**: Added a portable C implementation of BLAKE3 needed for key derivation.
2. **Protocol Framing**: Updated `aead_encrypt` to handle the SIP022 requirement where the first chunk (header) does not have a length prefix in the request stream.
3. **Key Derivation**: Integrated BLAKE3 for both Pre-Shared Key (PSK) derivation and session subkey derivation.
4. **Handshake**: Updated `ss_connector.c` to construct the mandatory SIP022 header (type, timestamp, padding, and address) and to skip the response header received from the server.
5. **Robustness**: Fixed a bug where encryption/decryption contexts were swapped in the connector and added missing system headers.


---
*PR created automatically by Jules for task [8943456336134348163](https://jules.google.com/task/8943456336134348163) started by @boytm*