### PR TITLE
Add basic authentication support

### DIFF
--- a/evhtp_proxy.c
+++ b/evhtp_proxy.c
@@ -55,6 +55,7 @@ struct evdns_base *evdns = NULL;
 #endif
 const char *g_socks_server = NULL;
 int g_socks_port = DEFAULT_SOCKS5_PORT;
+char *g_proxy_auth = NULL;
 int g_https_proxy = 0;
 int use_syslog = 0;
 int g_enable_nodelay = 0;
@@ -258,6 +259,9 @@ make_request(evhtp_connection_t * conn,
         if (strcasecmp(kv->key, "Proxy-Connection") == 0) {
             continue;
         }
+        if (g_proxy_auth && strcasecmp(kv->key, "Proxy-Authorization") == 0) {
+            continue;
+        }
         evhtp_kvs_add_kv(request->headers_out, evhtp_kv_new(kv->key,
             kv->val,
             kv->k_heaped,
@@ -333,6 +337,16 @@ frontend_cb(evhtp_request_t * req, void * arg) {
     if (strlen(host) > 255) {
         LOGE("domain %s too long", host);
         return evhtp_send_reply(req, EVHTP_RES_SERVERR);
+    }
+
+    if (g_proxy_auth) {
+        const char *auth = evhtp_kv_find(req->headers_in, "Proxy-Authorization");
+        if (auth == NULL || strncasecmp(auth, "Basic ", 6) != 0 || strcmp(auth + 6, g_proxy_auth + 6) != 0) {
+            evhtp_headers_add_header(req->headers_out,
+                evhtp_header_new("Proxy-Authenticate", "Basic realm=\"mproxy\"", 0, 0));
+            evhtp_send_reply(req, EVHTP_RES_PROXYAUTHREQ);
+            return;
+        }
     }
 
     /* Pause the frontend request while we run the backend requests. */
@@ -513,6 +527,7 @@ void usage(const char *program)
         "                        maximum allowed size of the client request body(unit MB, 0 allow any size, default 1MB)\n"
         "  --dns-forwarder <[bind_ip:]bind_port:forward_ip:forward_port> \n"
         "                        forward local dns request to dns server via tcp\n"
+        "  --auth <user:password> basic auth for proxy\n"
         "  -v, --verbose         verbose logging\n"
         "  -V, --version         show version number and quit\n"
         "  -h, --help            show help\n", DEFAULT_LISTEN_PORT);
@@ -536,6 +551,7 @@ enum {
     OPTION_TCP_NODELAY,
     OPTION_CLIENT_MAX_BODY_SIZE,
     OPTION_DNS_FORWARDER,
+    OPTION_AUTH,
 };
 
 int
@@ -579,6 +595,7 @@ main(int argc, char ** argv) {
 #endif
         {"client-max-body-size", required_argument, NULL, OPTION_CLIENT_MAX_BODY_SIZE},
         {"dns-forwarder", required_argument, NULL, OPTION_DNS_FORWARDER},
+        {"auth", required_argument, NULL, OPTION_AUTH},
         {"help", no_argument, NULL, 'h'},
         {"verbose", no_argument, NULL, 'v'},
         {"version", no_argument, NULL, 'V'},
@@ -653,6 +670,18 @@ main(int argc, char ** argv) {
             break;
         case OPTION_DNS_FORWARDER:
             dns_forwarder = optarg;
+            break;
+        case OPTION_AUTH:
+            {
+                char *auth_b64 = base64_encode((unsigned char *)optarg, strlen(optarg));
+                if (auth_b64) {
+                    g_proxy_auth = malloc(strlen(auth_b64) + 7);
+                    if (g_proxy_auth) {
+                        sprintf(g_proxy_auth, "Basic %s", auth_b64);
+                    }
+                    free(auth_b64);
+                }
+            }
             break;
         case 'V':
             version(argv[0]);

--- a/evhtp_proxy.c
+++ b/evhtp_proxy.c
@@ -56,6 +56,7 @@ struct evdns_base *evdns = NULL;
 const char *g_socks_server = NULL;
 int g_socks_port = DEFAULT_SOCKS5_PORT;
 char *g_proxy_auth = NULL;
+char *g_proxy_realm = "proxy";
 int g_https_proxy = 0;
 int use_syslog = 0;
 int g_enable_nodelay = 0;
@@ -342,8 +343,10 @@ frontend_cb(evhtp_request_t * req, void * arg) {
     if (g_proxy_auth) {
         const char *auth = evhtp_kv_find(req->headers_in, "Proxy-Authorization");
         if (auth == NULL || strncasecmp(auth, "Basic ", 6) != 0 || strcmp(auth + 6, g_proxy_auth + 6) != 0) {
+            char realm_header[512];
+            snprintf(realm_header, sizeof(realm_header), "Basic realm=\"%s\"", g_proxy_realm);
             evhtp_headers_add_header(req->headers_out,
-                evhtp_header_new("Proxy-Authenticate", "Basic realm=\"mproxy\"", 0, 0));
+                evhtp_header_new("Proxy-Authenticate", realm_header, 0, 1));
             evhtp_send_reply(req, EVHTP_RES_PROXYAUTHREQ);
             return;
         }
@@ -497,40 +500,41 @@ void usage(const char *program)
 {
     printf("\nUsage: %s [options]\n", program);
     printf(
-        "  -l <local_port>       proxy listen port, default %d\n"
-        "  -b <local_address>    local address to bind, default " DEFAULT_BIND_ADDRESS "\n"
+        "  -l <local_port>               proxy listen port, default %d\n"
+        "  -b <local_address>            local address to bind, default " DEFAULT_BIND_ADDRESS "\n"
 #ifndef ENABLE_SS
-        "  -p <server_port>      socks5 server port\n"
-        "  -s <server_address>   socks5 server address\n"
+        "  -p <server_port>              socks5 server port\n"
+        "  -s <server_address>           socks5 server address\n"
 #else
-        "  -p <server_port>      socks5/ss server port\n"
-        "  -s <server_address>   socks5/ss server address\n"
-        "  -m <encrypt_method>   encrypt method of remote ss server\n"
-        "  -k <password>         password of remote ss server\n"
-        "  --pac <pac_file>      pac file\n"
+        "  -p <server_port>              socks5/ss server port\n"
+        "  -s <server_address>           socks5/ss server address\n"
+        "  -m <encrypt_method>           encrypt method of remote ss server\n"
+        "  -k <password>                 password of remote ss server\n"
+        "  --pac <pac_file>              pac file\n"
 #endif
-        "  --dns <nameserver>    name server\n"
+        "  --dns <nameserver>            name server\n"
 #ifndef _WIN32
-        "  --user <user[:group]> set user and group\n"
-        "  --pid-file <path>     pid file\n"
+        "  --user <user[:group]>         set user and group\n"
+        "  --pid-file <path>             pid file\n"
 #endif
 #ifdef ENABLE_HTTPS_PROXY
-        "  --ssl-certificate <fullchain.pem> \n"
-        "                        set ssl certificate\n"
-        "  --ssl-certificate-key <privkey.pem> \n"
-        "                        set ssl private key\n"
+        "  --ssl-certificate <file>      set ssl certificate\n"
+        "  --ssl-certificate-key <file>  set ssl private key\n"
 #endif
 #ifdef TCP_NODELAY
-        "  --tcp-nodelay         enable TCP NODELAY\n"
+        "  --tcp-nodelay                 enable TCP NODELAY\n"
 #endif
-        "  --client-max-body-size <size> \n"
-        "                        maximum allowed size of the client request body(unit MB, 0 allow any size, default 1MB)\n"
-        "  --dns-forwarder <[bind_ip:]bind_port:forward_ip:forward_port> \n"
-        "                        forward local dns request to dns server via tcp\n"
-        "  --auth <user:password> basic auth for proxy\n"
-        "  -v, --verbose         verbose logging\n"
-        "  -V, --version         show version number and quit\n"
-        "  -h, --help            show help\n", DEFAULT_LISTEN_PORT);
+        "  --client-max-body-size <size>\n"
+        "                                maximum allowed size of the client request body\n"
+        "                                (unit MB, 0 allow any size, default 1MB)\n"
+        "  --dns-forwarder <addr>\n"
+        "                                forward local dns request to dns server via tcp\n"
+        "                                addr: [bind_ip:]bind_port:forward_ip:forward_port\n"
+        "  --auth <user:password>        basic auth for proxy\n"
+        "  --auth-realm <realm>          proxy auth realm, default proxy\n"
+        "  -v, --verbose                 verbose logging\n"
+        "  -V, --version                 show version number and quit\n"
+        "  -h, --help                    show help\n", DEFAULT_LISTEN_PORT);
 #ifdef ENABLE_SS
     char buf[4096] = {'\0'};
     enc_print_all_methods(buf, sizeof(buf)/sizeof(buf[0]));
@@ -552,6 +556,7 @@ enum {
     OPTION_CLIENT_MAX_BODY_SIZE,
     OPTION_DNS_FORWARDER,
     OPTION_AUTH,
+    OPTION_AUTH_REALM,
 };
 
 int
@@ -596,6 +601,7 @@ main(int argc, char ** argv) {
         {"client-max-body-size", required_argument, NULL, OPTION_CLIENT_MAX_BODY_SIZE},
         {"dns-forwarder", required_argument, NULL, OPTION_DNS_FORWARDER},
         {"auth", required_argument, NULL, OPTION_AUTH},
+        {"auth-realm", required_argument, NULL, OPTION_AUTH_REALM},
         {"help", no_argument, NULL, 'h'},
         {"verbose", no_argument, NULL, 'v'},
         {"version", no_argument, NULL, 'V'},
@@ -670,6 +676,9 @@ main(int argc, char ** argv) {
             break;
         case OPTION_DNS_FORWARDER:
             dns_forwarder = optarg;
+            break;
+        case OPTION_AUTH_REALM:
+            g_proxy_realm = optarg;
             break;
         case OPTION_AUTH:
             {

--- a/utils.c
+++ b/utils.c
@@ -137,3 +137,46 @@ void hexdump(FILE *out, const void *p, int len)
         line += thisline;
     }
 }
+
+static const char base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+char *base64_encode(const unsigned char *src, size_t len)
+{
+    unsigned char *out, *pos;
+    const unsigned char *end, *in;
+    size_t olen;
+
+    olen = len * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
+    out = malloc(olen);
+    if (out == NULL)
+        return NULL;
+
+    end = src + len;
+    in = src;
+    pos = out;
+    while (end - in >= 3) {
+        *pos++ = base64_chars[in[0] >> 2];
+        *pos++ = base64_chars[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+        *pos++ = base64_chars[((in[1] & 0x0f) << 2) | (in[2] >> 6)];
+        *pos++ = base64_chars[in[2] & 0x3f];
+        in += 3;
+    }
+
+    if (end - in > 0) {
+        *pos++ = base64_chars[in[0] >> 2];
+        if (end - in == 1) {
+            *pos++ = base64_chars[(in[0] & 0x03) << 4];
+            *pos++ = '=';
+        } else {
+            *pos++ = base64_chars[((in[0] & 0x03) << 4) | (in[1] >> 4)];
+            *pos++ = base64_chars[(in[1] & 0x0f) << 2];
+        }
+        *pos++ = '=';
+    }
+
+    *pos = '\0';
+    return (char *)out;
+}

--- a/utils.h
+++ b/utils.h
@@ -9,5 +9,6 @@ int write_pid_file(const char *pid_file);
 int change_user(const char *userspec);
 #endif
 void hexdump(FILE *out, const void *p, int len);
+char *base64_encode(const unsigned char *src, size_t len);
 
 #endif // __UTILS_H__


### PR DESCRIPTION
Added basic authentication support to the HTTP/HTTPS proxy using a new --auth command-line option. The implementation handles Proxy-Authorization headers and returns 407 status when authentication is required.

---
*PR created automatically by Jules for task [1865724147438121444](https://jules.google.com/task/1865724147438121444) started by @boytm*